### PR TITLE
Specify the database name when connecting

### DIFF
--- a/src/connection.lisp
+++ b/src/connection.lisp
@@ -51,10 +51,11 @@ A CLOS object of type 'database-connection is returned."
   (let ((cffi:*default-foreign-encoding* external-format))
     (garbage-pools:with-garbage-pool ()
       (let ((%login (garbage-pools:cleanup-register (%dblogin) #'%dbloginfree)))
-        (iter (for (key . value) in (list (cons host 1)       ;; set host
-                                          (cons user 2)       ;; set user
-                                          (cons password 3)   ;; set password
-                                          '("cl-mssql" . 5))) ;; set app
+        (iter (for (key . value) in (list (cons host 1)                         ;; set host
+                                          (cons user 2)                         ;; set user
+                                          (cons password 3)                     ;; set password
+                                          (cons (princ-to-string database) 14)  ;; set database
+                                          '("cl-mssql" . 5)))                   ;; set app
               (%dbsetlname %login (cffi-string key) value))
 
         (let ((%dbproc (garbage-pools:cleanup-register (%tdsdbopen %login (cffi-string host) 1)


### PR DESCRIPTION
This PR specifies the name of the database to connect to upon login.

This is required to work within an Azure SQL environment.

Before this change, the library always connects to the default database (`master` in our case). If the database we want to connect to is another database, then Azure SQL will fail, as it restrict the connection to the database you are initially connected to (so in this case `master`). So this PR sets the database name for the connection to the database we're actually interested in. That way, the `USE` statement won't be denied by Azure SQL.

Fixes #9 (and the related issue we are encountering as described in https://github.com/dimitri/pgloader/issues/1324#issuecomment-1220781465)