### PR TITLE
Export init and exit functions

### DIFF
--- a/mssql.asd
+++ b/mssql.asd
@@ -17,6 +17,7 @@
   ((:module :src
             :components
             ((:file "packages")
+             (:file "init" :depends-on ("mssql"))
              (:file "mssql" :depends-on ("packages"))
              (:file "connection" :depends-on ("mssql"))
              (:file "query" :depends-on ("connection"))

--- a/src/init.lisp
+++ b/src/init.lisp
@@ -1,0 +1,21 @@
+;;;; init.lisp
+;;;;
+;;;; This file is part of the cl-mssql library, released under Lisp-LGPL.
+;;;; See file COPYING for details.
+;;;;
+;;;; Author: Moskvitin Andrey <archimag@gmail.com>
+
+
+(in-package :mssql)
+
+;;; initialization
+
+(define-sybdb-function ("dbinit" %dbinit :check-retcode) %RETCODE)
+
+(define-sybdb-function ("dbexit" %dbexit) :void)
+
+(defun init ()
+  (%dbinit))
+
+(defun exit ()
+  (%dbexit))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -7,7 +7,10 @@
 
 (defpackage #:mssql
   (:use #:cl #:iter #:cffi)
-  (:export #:*database*
+  (:export #:init
+           #:exit
+
+           #:*database*
            #:database-connection
            #:connect
            #:connected-p


### PR DESCRIPTION
This PR exports the `dbinit` and `dbexit` functions (respectively as `init` and `exit`) so that calling programs can properly initialize (and uninitialize) the library.

While it seems that programs usually work without this, the library does then emit the following message:

```
Max connections reached, increase value of TDS_MAX_CONN
```

This happens because the library has not been initialized properly.

With this PR, programs can now initialize the library properly by calling the newly introduced functions, without having to do FFI themselves.