### PR TITLE
Remove excess "e"

### DIFF
--- a/src/query.lisp
+++ b/src/query.lisp
@@ -239,7 +239,7 @@
     (error "Unknow query format: ~A" format))
   (unless (= +no-more-results+ (%dbresults %dbproc))
     (let ((collumns (iter (for x from 1 to (%dbnumcols %dbproc))
-                          (collect (let ((name (foreign-string-to-lisp (%dbcolname %dbproc x))e))
+                          (collect (let ((name (foreign-string-to-lisp (%dbcolname %dbproc x))))
                                      (if (eql (third format-info) 'keyword-collumn)
                                          (field-name-s name)
                                          name))))))


### PR DESCRIPTION
Probably a bug in the "iterate" library.

(iter (for x from 1 to 2)
  (collect (let ((name (identity "x")e))  ;;<==excess "e" in let
    (format t "~A:~A~%" name x))))
x:1
x:2
(NIL NIL)

(let ((name (identity "x")e))
    (format t "~A:~A~%" name x))
; in: LET ((NAME (IDENTITY "x") E))
;     (NAME (IDENTITY "x") E)
;
; caught ERROR:
;   The LET binding spec (NAME (IDENTITY "x") E) is malformed.
;
; compilation unit finished
;   caught 1 ERROR condition

debugger invoked on a SB-INT:COMPILED-PROGRAM-ERROR in thread
#<THREAD "main thread" RUNNING {1001DA81B3}>:
  Execution of a form compiled with errors.
Form:
  (LET ((NAME (IDENTITY "x") E))
  (FORMAT T "~A:~A~%" NAME X))
Compile-time error:
  The LET binding spec (NAME (IDENTITY "x") E) is malformed.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

((LAMBDA ()))
   source: (LET ((NAME (IDENTITY "x") E))
             (FORMAT T "~A:~A~%" NAME X))
0]
0
