### PR TITLE
add macro foreach-rows-from-query

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -25,5 +25,6 @@
            #:commit-transaction
 
            #:query
+           #:foreach-rows-from-query
 
            #:call-remote-procedure))


### PR DESCRIPTION
If function "query" return a large result list(more than 10 million rows), the memory will explode.

### example:
```
(with-connection ("test" "sa" "password" "localhost")
  (when (connected-p *database*)
      (query "select count(*) from test;")))
```

> Max connections reached, increase value of TDS_MAX_CONN
> [5703]Changed language setting to us_english.
> [5701]Changed database context to 'test'.
> [5701]Changed database context to 'test'.
> 
> ((40000000))

### memory exploded:
```
(with-connection ("test" "sa" "password" "localhost")
  (when (connected-p *database*)
      (length (query "select * from test;"))))
```

> Max connections reached, increase value of TDS_MAX_CONN
> [5703]Changed language setting to us_english.
> [5701]Changed database context to 'test'.
> [5701]Changed database context to 'test'.
> 
> Heap exhausted during garbage collection: 32 bytes available, 112 requested.
>         Immobile Object Counts
>  Gen layout fdefn symbol   code  Boxed   Cons    Raw   Code  SmMix  Mixed  LgRaw LgCode  LgMix Waste%       Alloc        Trig   Dirty GCs Mem-age
>   2     69   2962    205   3471    107   7598  11782      4     19     19     10      0     34    0.5   638463472     2000000   19573   0  0.9891
>   3      0      0      0      0      0      0      0      0      0      0      0      0      0    0.0           0     2000000       0   0  0.0000
>   4      0      0      0      0      0      0      0      0      0      0      0      0      0    0.0           0     2000000       0   0  0.0000
>   5      0      0      0      0      0      0      0      0      0      0      0      0      0    0.0           0     2000000       0   0  0.0000
> fatal error encountered in SBCL pid 1550754 tid 1550754:
> GC invariant lost, file "gencgc.c", line 523
> 
> Welcome to LDB, a low-level debugger for the Lisp runtime environment.
> (GC in progress, oldspace=2, newspace=7)

### Add Macro "foreach-rows-from-query":
```
(with-connection ("test" "sa" "password" "localhost")
  (when (connected-p *database*)
      (foreach-rows-from-query (test "select * from test;" test))))
```

> Max connections reached, increase value of TDS_MAX_CONN
> [5703]Changed language setting to us_english.
> [5701]Changed database context to 'test'.
> [5701]Changed database context to 'test'.
> 40000000

### more example of "foreach-rows-from-query":
```
(with-connection ("test" "sa" "password" "localhost")
  (when (connected-p *database*)
      (foreach-rows-from-query (test "select top 10 * from test;"
                                 (format t "total rows: ~A" test))
        (do ((i 1 (1+ i)))
            ((> i (test-max-cidx)))
            (if (< i (test-max-cidx))
                (format t "~A," (test-cidx->name i))
                (format t "~A~%"(test-cidx->name i))))
        (do ((i 1 (1+ i)))
            ((> i (test-max-cidx)))
            (cond ((= i 1) (format t "row ~A: ~A," test (test-cidx->val i)))
                  ((< i (test-max-cidx)) (format t "~A," (test-cidx->val i)))
                  (t (format t "~A~%"(test-cidx->val i))))))))
```

> Max connections reached, increase value of TDS_MAX_CONN
> [5703]Changed language setting to us_english.
> [5701]Changed database context to 'test'.
> [5701]Changed database context to 'test'.
> id,col1,col2,col3,col4,col5
> row 1: 1,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:000
> row 2: 2,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:000
> row 3: 3,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:003
> row 4: 4,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:007
> row 5: 5,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:007
> row 6: 6,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:007
> row 7: 7,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:010
> row 8: 8,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:010
> row 9: 9,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:010
> row 10: 10,0,0.0d0,0.0,abcxyz,2024-09-01 13:36:48:010
> total rows: 10
> NIL
